### PR TITLE
feat: Add Lambda versioning to API Gateway integration

### DIFF
--- a/pu_utils/aws/api/_gateway.py
+++ b/pu_utils/aws/api/_gateway.py
@@ -25,16 +25,17 @@ class RestEndpoint(ComponentResource):
     """Create a lambda-backed REST API endpoint"""
 
     def __init__(
-        self,
-        name: str,
-        path: str,
-        method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
-        api_id: Input[str],
-        gateway_execution_arn: Input[str],
-        resource_id: Input[str],
-        function: Function,
-        authorizer_id: Input[str] | None = None,
-        opts: ResourceOptions | None = None,
+            self,
+            name: str,
+            path: str,
+            lambda_version: str,
+            method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
+            api_id: Input[str],
+            gateway_execution_arn: Input[str],
+            resource_id: Input[str],
+            function: Function,
+            authorizer_id: Input[str] | None = None,
+            opts: ResourceOptions | None = None,
     ) -> None:
         super().__init__("pu-utils:index:RestEndpoint", name, None, opts)
         self.function = function
@@ -49,6 +50,19 @@ class RestEndpoint(ComponentResource):
             resource_id=resource_id,
             opts=ResourceOptions(parent=self),
         )
+
+        # Conditionally set the ARN
+        lambda_arn = (
+            self.function.invoke_arn
+            if lambda_version == "0"
+            else self.function.invoke_arn.apply(
+                lambda arn: arn.replace("/invocations", f":{lambda_version}/invocations")
+            )
+        )
+
+        # Debugging: Print the resolved ARN
+        lambda_arn.apply(lambda resolved_arn: print(f"Resolved Lambda ARN: {resolved_arn}"))
+
         self.integration = Integration(
             name,
             # Must read from method to enforce creation order, reading from args may
@@ -57,12 +71,13 @@ class RestEndpoint(ComponentResource):
             http_method=self.method.http_method,
             integration_http_method="POST",
             type="AWS_PROXY",
-            uri=self.function.invoke_arn,
+            uri=lambda_arn,  # Use the conditionally resolved ARN
             rest_api=api_id,
             resource_id=resource_id,
             opts=ResourceOptions(parent=self),
         )
         self.register_outputs({})
+
 
     def resources(self) -> list[Resource]:
         return [self.integration, self.method]
@@ -78,12 +93,12 @@ class RestGateway(ComponentResource):
         return self._api.execution_arn
 
     def __init__(
-        self,
-        name: str,
-        namer: Namer,
-        authorizer_func: Function | None = None,
-        gateway_id: Input[str] | None = None,
-        opts: ResourceOptions | None = None,
+            self,
+            name: str,
+            namer: Namer,
+            authorizer_func: Function | None = None,
+            gateway_id: Input[str] | None = None,
+            opts: ResourceOptions | None = None,
     ) -> None:
         """
         Create a REST Gateway (API Gateway v1)
@@ -107,19 +122,21 @@ class RestGateway(ComponentResource):
         # May also add catch-all route and return mock 404
 
     def add_endpoint(
-        self,
-        name: str,
-        method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
-        path: str,
-        function: Function,
-        *,
-        authorized: bool = True,
+            self,
+            name: str,
+            method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
+            path: str,
+            function: Function,
+            lambda_version: str,
+            *,
+            authorized: bool = True,
     ) -> None:
         self._endpoints.append(
             RestEndpoint(
                 name,
                 path=path,
                 resource_id=self._route_resource_id(path),
+                lambda_version=lambda_version,
                 method=method,
                 api_id=self._api.id,
                 gateway_execution_arn=self._api.execution_arn,

--- a/pu_utils/aws/api/_gateway.py
+++ b/pu_utils/aws/api/_gateway.py
@@ -25,17 +25,17 @@ class RestEndpoint(ComponentResource):
     """Create a lambda-backed REST API endpoint"""
 
     def __init__(
-            self,
-            name: str,
-            path: str,
-            lambda_version: str,
-            method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
-            api_id: Input[str],
-            gateway_execution_arn: Input[str],
-            resource_id: Input[str],
-            function: Function,
-            authorizer_id: Input[str] | None = None,
-            opts: ResourceOptions | None = None,
+        self,
+        name: str,
+        path: str,
+        lambda_version: str,
+        method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
+        api_id: Input[str],
+        gateway_execution_arn: Input[str],
+        resource_id: Input[str],
+        function: Function,
+        authorizer_id: Input[str] | None = None,
+        opts: ResourceOptions | None = None,
     ) -> None:
         super().__init__("pu-utils:index:RestEndpoint", name, None, opts)
         self.function = function
@@ -93,12 +93,12 @@ class RestGateway(ComponentResource):
         return self._api.execution_arn
 
     def __init__(
-            self,
-            name: str,
-            namer: Namer,
-            authorizer_func: Function | None = None,
-            gateway_id: Input[str] | None = None,
-            opts: ResourceOptions | None = None,
+        self,
+        name: str,
+        namer: Namer,
+        authorizer_func: Function | None = None,
+        gateway_id: Input[str] | None = None,
+        opts: ResourceOptions | None = None,
     ) -> None:
         """
         Create a REST Gateway (API Gateway v1)
@@ -122,14 +122,14 @@ class RestGateway(ComponentResource):
         # May also add catch-all route and return mock 404
 
     def add_endpoint(
-            self,
-            name: str,
-            method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
-            path: str,
-            function: Function,
-            lambda_version: str,
-            *,
-            authorized: bool = True,
+        self,
+        name: str,
+        method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
+        path: str,
+        function: Function,
+        lambda_version: str,
+        *,
+        authorized: bool = True,
     ) -> None:
         self._endpoints.append(
             RestEndpoint(

--- a/pu_utils/aws/lambda_.py
+++ b/pu_utils/aws/lambda_.py
@@ -434,6 +434,7 @@ class ContainerLambda(ComponentResource):
     ) -> Function:
         return Function(
             name,
+            publish=True,
             name=function_name,
             role=role_arn,
             image_uri=image_uri,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plm-utils"
-version = "0.1.0"
+version = "0.1.3"
 description = "Random stuff to help writing Pulumi scripts easier"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This commit adds support for specifying a Lambda function version when creating API Gateway endpoints.  This allows for deploying specific versions of Lambda functions to API Gateway, improving control over deployments and reducing the risk of unintended changes.

Additionally, the `plm-utils` package version has been bumped to 0.1.3.  A debug print statement has been added to display the resolved Lambda ARN for easier troubleshooting.  Finally, all Lambda functions created now publish their versions.